### PR TITLE
Fix packaging and type hint bug

### DIFF
--- a/parsec/__init__.py
+++ b/parsec/__init__.py
@@ -1,0 +1,1 @@
+from .core import *

--- a/parsec/core.py
+++ b/parsec/core.py
@@ -239,12 +239,12 @@ def pure(r):
     return PureParser(r)
 
 
-def string(s: string):
+def string(s: str) -> Parser:
     return StringParser(s)
 
 
-def regex(s: string):
-    return RegexParser(s)
+def regex(pattern: str) -> Parser:
+    return RegexParser(pattern)
 
 
 def letters():


### PR DESCRIPTION
## Summary
- move `core.py` into new `parsec` package
- expose library exports via `parsec/__init__.py`
- correct type hints for `string` and `regex` helper functions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68420bebf7b48323a51e4cd93ff5b207