### PR TITLE
Add assertion for kleene parser failure and fix parser

### DIFF
--- a/core_test.py
+++ b/core_test.py
@@ -71,6 +71,7 @@ class TestCombinatorialParsing(unittest.TestCase):
 
         ctx = parser.parse("123")
         self.assertTrue(ctx.failed)
+        self.assertEqual(ctx.position, 0)
 
     def test_letters_parser(self):
         parser = letters()

--- a/parsec/core.py
+++ b/parsec/core.py
@@ -181,6 +181,7 @@ class KleeneParser(Parser):
     def parse_with_context(self, ctx: ParsingContext) -> ParsingContext:
         match_count = 0
         results = []
+        original_ctx = ctx
         while True:
             local_ctx = self.parser.parse_with_context(ctx)
             if local_ctx.failed:
@@ -189,7 +190,7 @@ class KleeneParser(Parser):
             match_count += 1
             results += [ctx.result]
         if match_count < self.min:
-            return ctx.fail(
+            return original_ctx.fail(
                 f"expected to match at least {self.min}x but matched {match_count}x"
             )
         return ctx.update_result(results)


### PR DESCRIPTION
## Summary
- ensure `KleeneParser` resets context position on failure
- check that `test_kleene_parser` keeps the original position when failing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68422866889483238e80fb66605414ed